### PR TITLE
Enable Windows

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,15 +36,15 @@ build:
       - copy libclang.dll %LIBRARY_BIN%\ || goto :eof      # [win]
       - copy %RECIPE_DIR%\LICENSE %SRC_DIR%\ || goto :eof  # [win]
 
-requirements:
-  build:
+requirements:    # [not win]
+  build:         # [not win]
     - cmake      # [not win]
     - toolchain  # [not win]
     - flex       # [not win]
     - bison      # [not win]
     - python     # [not win]
     - libiconv   # [not win]
-  run:
+  run:           # [not win]
     - m4         # [not win]
     - libiconv   # [not win]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ source:
   
 build:
   number: 0
-  skip: True  # [not py35]
+  skip: True  # [not py35 and unix]
   script:                                                  # [win]
       - mkdir %SCRIPTS%                                    # [win]
       - copy doxygen.exe %SCRIPTS%\ || goto :eof           # [win]


### PR DESCRIPTION
Makes some fixes for enabling Windows and re-rendering the feedstock in PR ( https://github.com/conda-forge/doxygen-feedstock/pull/1 ). This is in response to problems noted in issue ( https://github.com/conda-forge/conda-smithy/issues/426 ).